### PR TITLE
Fix image name in workflows

### DIFF
--- a/.github/workflows/order-service.yml
+++ b/.github/workflows/order-service.yml
@@ -10,9 +10,6 @@ on:
     paths:
     - 'order-service/**'
 
-env:
-  IMAGE_NAME: order-service
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -55,6 +52,6 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
           registry: docker.pkg.github.com
-          image_name: $IMAGE_NAME
+          image_name: order-service
           dockerfile: ../Dockerfile
           context: order-service

--- a/.github/workflows/payment-service.yml
+++ b/.github/workflows/payment-service.yml
@@ -10,9 +10,6 @@ on:
     paths:
     - 'payment-service/**'
 
-env:
-  IMAGE_NAME: payment-service
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -55,6 +52,6 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
           registry: docker.pkg.github.com
-          image_name: $IMAGE_NAME
+          image_name: payment-service
           dockerfile: ../Dockerfile
           context: payment-service

--- a/.github/workflows/stock-service.yml
+++ b/.github/workflows/stock-service.yml
@@ -10,9 +10,6 @@ on:
     paths:
     - 'stock-service/**'
 
-env:
-  IMAGE_NAME: stock-service
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -55,6 +52,6 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
           registry: docker.pkg.github.com
-          image_name: $IMAGE_NAME
+          image_name: stock-service
           dockerfile: ../Dockerfile
           context: stock-service

--- a/.github/workflows/user-service.yml
+++ b/.github/workflows/user-service.yml
@@ -10,9 +10,6 @@ on:
     paths:
     - 'user-service/**'
 
-env:
-  IMAGE_NAME: user-service
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -55,6 +52,6 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
           registry: docker.pkg.github.com
-          image_name: $IMAGE_NAME
+          image_name: user-service
           dockerfile: ../Dockerfile
           context: user-service


### PR DESCRIPTION
This should fix a small issue with the GitHub workflows for building and publishing the Docker images by removing an unnecessary environment variable.