### PR TITLE
Add rolling restart to deploy updated image

### DIFF
--- a/.github/workflows/order-service.yml
+++ b/.github/workflows/order-service.yml
@@ -86,8 +86,10 @@ jobs:
         working-directory: ${{ env.SERVICE_DIR }}
         run: |-
           kubectl apply -f k8s/deployment-cass.yaml
+          kubectl rollout restart deployment/order-service-cass
 
       - name: Deploy with PostgreSQL backend
         working-directory: ${{ env.SERVICE_DIR }}
         run: |-
           kubectl apply -f k8s/deployment-psql.yaml
+          kubectl rollout restart deployment/order-service-psql

--- a/.github/workflows/payment-service.yml
+++ b/.github/workflows/payment-service.yml
@@ -86,8 +86,10 @@ jobs:
         working-directory: ${{ env.SERVICE_DIR }}
         run: |-
           kubectl apply -f k8s/deployment-cass.yaml
+          kubectl rollout restart deployment/payment-service-cass
 
       - name: Deploy with PostgreSQL backend
         working-directory: ${{ env.SERVICE_DIR }}
         run: |-
           kubectl apply -f k8s/deployment-psql.yaml
+          kubectl rollout restart deployment/payment-service-psql

--- a/.github/workflows/stock-service.yml
+++ b/.github/workflows/stock-service.yml
@@ -86,8 +86,10 @@ jobs:
         working-directory: ${{ env.SERVICE_DIR }}
         run: |-
           kubectl apply -f k8s/deployment-cass.yaml
+          kubectl rollout restart deployment/stock-service-cass
 
       - name: Deploy with PostgreSQL backend
         working-directory: ${{ env.SERVICE_DIR }}
         run: |-
           kubectl apply -f k8s/deployment-psql.yaml
+          kubectl rollout restart deployment/stock-service-psql

--- a/.github/workflows/user-service.yml
+++ b/.github/workflows/user-service.yml
@@ -86,8 +86,10 @@ jobs:
         working-directory: ${{ env.SERVICE_DIR }}
         run: |-
           kubectl apply -f k8s/deployment-cass.yaml
+          kubectl rollout restart deployment/user-service-cass
 
       - name: Deploy with PostgreSQL backend
         working-directory: ${{ env.SERVICE_DIR }}
         run: |-
           kubectl apply -f k8s/deployment-psql.yaml
+          kubectl rollout restart deployment/user-service-psql


### PR DESCRIPTION
This PR adds a command (that I forgot in #18) to the CI pipelines that rolls out a restart of the deployed microservices which will make them use the latest image.