### PR TITLE
Always return payment status

### DIFF
--- a/payment-service/routes.py
+++ b/payment-service/routes.py
@@ -30,13 +30,10 @@ def create_app(db: Database):
     @service.route('/status/<uuid:order_id>', methods=["GET"])
     def get_order_status(order_id):
         order_status = db.get_payment_status(order_id)
-        if order_status is not None:
-            return make_response(jsonify({
-                "order_id": order_id,
-                "status": order_status
-            }), HTTPStatus.OK)
-        else:
-            return make_response(jsonify(), HTTPStatus.NOT_FOUND)
+        return make_response(jsonify({
+            "order_id": order_id,
+            "status": order_status == "PAID"
+        }), HTTPStatus.OK)
 
     return service
 


### PR DESCRIPTION
Resolves #26 

- Makes sure the `payment/status` route always returns a paid status instead of a 404 if the order was not known (to the payment service).