### PR TITLE
Remove unused primary key from orders-table

### DIFF
--- a/order-service/database/cassandra.py
+++ b/order-service/database/cassandra.py
@@ -111,7 +111,7 @@ class CassandraDB(Database):
         ''')
         self.connection.set_keyspace(config['database'])
         self.connection.execute('''
-        CREATE TABLE IF NOT EXISTS orders (order_id uuid, user_id uuid, PRIMARY KEY (order_id))
+        CREATE TABLE IF NOT EXISTS orders (order_id uuid, user_id uuid, PRIMARY KEY (order_id));
         ''')
 
         self.connection.execute('''


### PR DESCRIPTION
This removes the user_id from the primary key.
On a single-node minikube setup this reduced aggregated response times by 10% and more.

No need to redeploy the whole setup, you can do the changes in the kubernetes dashboard:
* click execute to create a shell in the cassandra pod
* cqlsh -u cassandra -p servicedev
* use order_service;
* drop table orders;
* CREATE TABLE orders (order_id uuid, user_id uuid, PRIMARY KEY (order_id));