### PR TITLE
Add clustering for order_items

### DIFF
--- a/order-service/database/cassandra.py
+++ b/order-service/database/cassandra.py
@@ -115,5 +115,5 @@ class CassandraDB(Database):
         ''')
 
         self.connection.execute('''
-        CREATE TABLE IF NOT EXISTS order_items (order_id uuid, item_id uuid, amount int, PRIMARY KEY (order_id, item_id))
+        CREATE TABLE IF NOT EXISTS order_items (order_id uuid, item_id uuid, amount int, PRIMARY KEY (order_id, item_id)) WITH CLUSTERING ORDER BY (item_id DESC);
         ''')


### PR DESCRIPTION
Deployment similar to #33.
This clusters together all items of an order to a single node, which should make some queries faster.
It works for me, however I was not able to reasonably test performance.